### PR TITLE
Fix bug where previous run data was ignored, resulting in duplicate entries

### DIFF
--- a/scripts/old_psn_product_fetcher.py
+++ b/scripts/old_psn_product_fetcher.py
@@ -106,7 +106,7 @@ def main(args):
     print("language code: `{}`, country code: `{}`".format(language_code, country_code))
     print("starting at `{}`".format(start_time))
 
-    global BASE_URL, FILE, FILE_BASE
+    global BASE_URL, FILE, FILE_BASE, PRODUCT_LIST, CONTAINER_LIST
 
     FILE_BASE = str(args.output_file_directory)
     BASE_URL = f'https://store.playstation.com/valkyrie-api/{language_code}/{country_code}/999'


### PR DESCRIPTION
I've only given this a short test, but this appears to have been the root cause.

If we don't declare `PRODUCT_LIST` and `CONTAINER_LIST` as `global` before we load the previous run data, then the previous run data is stored in the local scope. So, it gets discarded before the run starts. 
Since the global scoped `PRODUCT_LIST` and `CONTAINER_LIST` are empty, the script will save all content IDs it finds. It then appends them to the bottom of the existing file because we opened as `r+` and moved the cursor to the end with `FILE.read().splitlines()`